### PR TITLE
TDK-7908: L2 Tests for Power Manager

### DIFF
--- a/docs/pages/plat_power_L2_Low-Level_TestSpecification.md
+++ b/docs/pages/plat_power_L2_Low-Level_TestSpecification.md
@@ -1,0 +1,124 @@
+# PLAT POWER L2 Low Level Test Specification and Procedure Documentation
+
+## Table of Contents
+
+- [PLAT POWER L2 Low Level Test Specification and Procedure Documentation](#plat-power-l2-low-level-test-specification-and-procedure-documentation)
+
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+    - [Acronyms, Terms and Abbreviations](#acronyms-terms-and-abbreviations)
+    - [Definitions](#definitions)
+    - [References](#references)
+  - [Level 2 Test Procedure](#level-2-test-procedure)
+
+## Overview
+
+This document describes the level 2 testing suite for the PLAT POWER module.
+
+### Acronyms, Terms and Abbreviations
+
+- `HAL` \- Hardware Abstraction Layer, may include some common components
+- `UT`  \- Unit Test(s)
+- `OEM`  \- Original Equipment Manufacture
+- `SoC`  \- System on a Chip
+
+### Definitions
+
+  - `ut-core` \- Common Testing Framework <https://github.com/rdkcentral/ut-core>, which wraps a open-source framework that can be expanded to the requirements for future framework.
+
+### References
+- `High Level Test Specification` - [powermanager_tests.md](powermanager_tests.md)
+
+## Level 2 Test Procedure
+
+The following functions are expecting to test the module operates correctly.
+
+### Test 1
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_plat_power_SetAndGetPowerState`|
+|Description|Set various power states and retrieve it for verification|
+|Test Group|Module : 02|
+|Test Case ID|001|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the platform using PLAT_INIT | None | PWRMGR_SUCCESS | Should be successful |
+| 02 | Set variious power states using PLAT_API_SetPowerState | powerState = PWRMGR_POWERSTATE_OFF to PWRMGR_POWERSTATE_MAX | PWRMGR_SUCCESS | Should be successful |
+| 03 | Get the current power state using PLAT_API_GetPowerState and verify| getState = valid buffer | PWRMGR_SUCCESS, getState = powerState | Should be successful |
+| 04 | Terminate the platform using PLAT_TERM | None | PWRMGR_SUCCESS | Should be successful |
+
+
+```mermaid
+graph TB
+A[Call PLAT_INIT] -->|PWRMGR_SUCCESS| B{Call PLAT_API_SetPowerState <br> with various power states}
+B -->|PWRMGR_SUCCESS| C[Call PLAT_API_GetPowerState]
+C -->D[Verify get and <br> set power states]
+D -->|PWRMGR_SUCCESS| B
+B -->|End of loop|L[Call PLAT_TERM]
+L -->|PWRMGR_SUCCESS| M[Test case success]
+A -->|Failure| N[Test case fail]
+L -->|Failure| T[Test case fail]
+```
+
+
+
+### Test 2
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_plat_power_SetAndGetWakeupSrc`|
+|Description|Set status of various wakeup sources and retrieves status for verification based on the platform configuration|
+|Test Group|Module : 02|
+|Test Case ID|002|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the platform using PLAT_INIT | None | PWRMGR_SUCCESS | Should be successful |
+| 02 | Set wakeup source to true using PLAT_API_SetWakeupSrc for each source type | srcType = PWRMGR_WAKEUPSRC_VOICE to PWRMGR_WAKEUPSRC_MAX, enable = true | PWRMGR_SUCCESS | Should be successful |
+| 03 | Get wakeup source status using PLAT_API_GetWakeupSrc for each source type and verify| srcType = PWRMGR_WAKEUPSRC_VOICE to PWRMGR_WAKEUPSRC_MAX | PWRMGR_SUCCESS, enable = true | Should be successful |
+| 04 | Set wakeup source to false using PLAT_API_SetWakeupSrc for each source type | srcType = PWRMGR_WAKEUPSRC_VOICE to PWRMGR_WAKEUPSRC_MAX, enable = false | PWRMGR_SUCCESS | Should be successful |
+| 05 | Get wakeup source status using PLAT_API_GetWakeupSrc for each source type and verify| srcType = PWRMGR_WAKEUPSRC_VOICE to PWRMGR_WAKEUPSRC_MAX | PWRMGR_SUCCESS, enable = false | Should be successful |
+| 06 | Terminate the platform using PLAT_TERM | None | PWRMGR_SUCCESS | Should be successful |
+
+
+```mermaid
+graph TB
+A[Call PLAT_INIT] -->|PWRMGR_SUCCESS| B{For each wakeup source type <br> in PWRMGR_WakeupSrcType_t}
+B --> C[Call PLAT_API_SetWakeupSrc <br> and enable set to true]
+C -->|PWRMGR_SUCCESS| D[Call PLAT_API_GetWakeupSrc <br> and verify]
+D -->|PWRMGR_SUCCESS, <br>enable = true| E[Call PLAT_API_SetWakeupSrc <br> and enable set to false]
+E -->|PWRMGR_SUCCESS| F[Call PLAT_API_GetWakeupSrc and verify]
+F -->|PWRMGR_SUCCESS, <br> enable = false| B
+A -->|Failure| G[Test case fail]
+B --> L[Call PLAT_TERM]
+L -->|PWRMGR_SUCCESS| M[Test case success]
+L -->|Failure| N[Test case fail]
+```
+
+

--- a/src/main.c
+++ b/src/main.c
@@ -1,105 +1,42 @@
-/**
-*  If not stated otherwise in this file or this component's LICENSE
-*  file the following copyright and licenses apply:
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:*
+* Copyright 2024 RDK Management
 *
-*  Copyright 2022 RDK Management
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
 *
-*  Licensed under the Apache License, Version 2.0 (the License);
-*  you may not use this file except in compliance with the License.
-*  You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
 *
-*  http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing, software
-*  distributed under the License is distributed on an AS IS BASIS,
-*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*  See the License for the specific language governing permissions and
-*  limitations under the License.
-*/
-
-/**
- * @addtogroup HPK Hardware Porting Kit
- * @{
- * @par The Hardware Porting Kit
- * HPK is the next evolution of the well-defined Hardware Abstraction Layer
- * (HAL), but augmented with more comprehensive documentation and test suites
- * that OEM or SOC vendors can use to self-certify their ports before taking
- * them to RDKM for validation or to an operator for final integration and
- * deployment. The Hardware Porting Kit effectively enables an OEM and/or SOC
- * vendor to self-certify their own Video Accelerator devices, with minimal RDKM
- * assistance.
- *
- */
-
-/**
- * @addtogroup POWER_MANAGER Power Manager Module
- * @{
- */
-
-/**
- * @defgroup POWER_MANAGER_HALTEST Power Manager HAL Tests
- * @{
- *
- */
-
-/**
- * @defgroup PLAT_POWER_HALTEST_MAIN Power Manager HAL Tests Main File
- * @{
- * @parblock
- *
- * ### Tests for Power Manager HAL :
- *
- * This is to ensure that the API meets the operational requirements of the module across all vendors.
- *
- * **Pre-Conditions:** None @n
- * **Dependencies:** None @n
- *
- * Refer to API Definition specification documentation : [power-manager_halSpec.md](../../docs/pages/power-manager_halSpec.md)
- *
- * @endparblock
- */
-
-/**
-* @file main.c
-*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 */
 
 #include <ut.h>
 
-extern int UT_register_APIDEF_l1_tests( void );
-extern int UT_register_APIDEF_l2_tests( void );
+extern int register_hal_l2_tests( void );
 
-int main(int argc, char** argv) 
+int main(int argc, char** argv)
 {
-	int registerReturn = 0;
-
-	/* Register tests as required, then call the UT-main to support switches and triggering */
-	UT_init( argc, argv );
-
-	/* Check if tests are registered successfully */
-
-	registerReturn = UT_register_APIDEF_l1_tests();
-	if ( registerReturn == -1 )
-	{
-		printf("\n UT_register_APIDEF_l1_tests() returned failure");
-		return -1;
-	}
-
-	registerReturn = UT_register_APIDEF_l2_tests();
-	if ( registerReturn == -1 )
-	{	
-		printf("\n UT_register_APIDEF_l2_tests() returned failure");
-		return -1;
-	}
-
-	/* Begin test executions */
-	UT_run_tests();
-
-	return 0;
-
+    int registerReturn = 0;
+    /* Register tests as required, then call the UT-main to support switches and triggering */
+    UT_init( argc, argv );
+    /* Check if tests are registered successfully */
+    registerReturn = register_hal_l2_tests();
+    if (registerReturn == 0)
+    {
+        printf("register_hal_l2_tests() returned success");
+    }
+    else
+    {
+        printf("register_hal_l2_tests() returned failure");
+        return 1;
+    }
+    /* Begin test executions */
+    UT_run_tests();
+    return 0;
 }
-
-/** @} */ // End of PLAT_POWER_HALTEST_MAIN
-/** @} */ // End of POWER_MANAGER_HALTEST
-/** @} */ // End of POWER_MANAGER
-/** @} */ // End of HPK

--- a/src/test_l2_plat_power.c
+++ b/src/test_l2_plat_power.c
@@ -1,115 +1,186 @@
-/**
-*  If not stated otherwise in this file or this component's LICENSE
-*  file the following copyright and licenses apply:
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:*
+* Copyright 2024 RDK Management
 *
-*  Copyright 2022 RDK Management
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
 *
-*  Licensed under the Apache License, Version 2.0 (the License);
-*  you may not use this file except in compliance with the License.
-*  You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
 *
-*  http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing, software
-*  distributed under the License is distributed on an AS IS BASIS,
-*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*  See the License for the specific language governing permissions and
-*  limitations under the License.
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 */
-
-/**
- * @addtogroup HPK Hardware Porting Kit
- * @{
- * @par The Hardware Porting Kit
- * HPK is the next evolution of the well-defined Hardware Abstraction Layer
- * (HAL), but augmented with more comprehensive documentation and test suites
- * that OEM or SOC vendors can use to self-certify their ports before taking
- * them to RDKM for validation or to an operator for final integration and
- * deployment. The Hardware Porting Kit effectively enables an OEM and/or SOC
- * vendor to self-certify their own Video Accelerator devices, with minimal RDKM
- * assistance.
- *
- */
-
-/**
- * @addtogroup POWER_MANAGER Power Manager Module
- * @{
- */
-
-/**
- * @addtogroup POWER_MANAGER_HALTEST Power Manager HAL Tests
- * @{
- *
- */
-
-/**
- * @defgroup PLAT_POWER_HALTEST_L2 Power Manager HAL Test L2 File
- * @{
- * @parblock
- *
- * ### L2 Tests for Power Manager HAL :
- *
- * Level 2 module tests will perform module level testing by exercising the full set of APIs to validate various use cases.
- * This is to ensure that the APIs meets the operational requirements of the module across all vendors.
- *
- * **Pre-Conditions:**  None @n
- * **Dependencies:** None @n
- *
- * Refer to API Definition specification documentation : [power-manager_halSpec.md](../../docs/pages/power-manager_halSpec.md)
- *
- * @endparblock
- */
 
 /**
 * @file test_l2_plat_power.c
+* @page plat_power Level 2 Tests
 *
+* ## Module's Role
+* This module includes Level 2 functional tests (success and failure scenarios).
+* This is to ensure that the plat_power APIs meet the requirements across all vendors.
+*
+* **Pre-Conditions:**  None@n
+* **Dependencies:** None@n
+*
+* Ref to API Definition specification documentation : [plat-power_halSpec.md](../../docs/pages/plat-power_halSpec.md)
 */
-
-#include <string.h>
-#include <stdlib.h>
 
 #include <ut.h>
 #include <ut_log.h>
+#include <ut_kvp_profile.h>
+#include "plat_power.h"
+
+static int gTestGroup = 2;
+static int gTestID = 1;
 
 /**
-* @brief TODO Describe the object of the test
+* @brief Test for setting and getting power state in the power management module
 *
-* TODO Add the description of what is tested and why in this test
+* This test function first initializes the power management module using `PLAT_INIT` and checks if it returns `PWRMGR_SUCCESS`. Then it sets and gets the power state for each power state defined in `PWRMgr_PowerState_t` using `PLAT_API_SetPowerState` and `PLAT_API_GetPowerState` respectively, and checks if the set and get operations are successful and the power state is as expected. Finally, it terminates the power management module using `PLAT_TERM` and checks if it returns `PWRMGR_SUCCESS`.
 *
-* **Test Group ID:** TODO Add the group this test belongs to - Basic (for L1): 01 / Module (L2): 02 / Stress (L2): 03)@n
-* **Test Case ID:** TODO Add the ID of the test case so that it can be logically tracked in the logs@n
+* **Test Group ID:** 02@n
+* **Test Case ID:** 001@n
 *
 * **Test Procedure:**
-* Refer to UT specification documentation [l2_module_test_specification.md](l2_module_test_specification.md)
+* Refer to UT specification documentation [plat_power_L2_Low-Level_TestSpecification.md](../../docs/pages/plat_power_L2_Low-Level_TestSpecification.md)
 */
-void test_l2_plat_power (void)
+
+void test_l2_plat_power_SetAndGetPowerState(void)
 {
-	UT_FAIL("This function needs to be implemented!");
+    gTestID = 1;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    pmStatus_t status;
+    PWRMgr_PowerState_t powerState, getState;
+
+    UT_LOG_DEBUG("Invoking PLAT_INIT");
+    status = PLAT_INIT();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, PWRMGR_SUCCESS);
+
+    for (powerState = PWRMGR_POWERSTATE_OFF; powerState < PWRMGR_POWERSTATE_MAX ; powerState++)
+    {
+        UT_LOG_DEBUG("Invoking PLAT_API_SetPowerState with powerState: %d", powerState);
+        status = PLAT_API_SetPowerState(powerState);
+        UT_LOG_DEBUG("Return status: %d", status);
+        UT_ASSERT_EQUAL(status, PWRMGR_SUCCESS);
+        if (status != PWRMGR_SUCCESS)
+        {
+            UT_LOG_ERROR("Failed to set power state");
+            continue;
+        }
+
+        UT_LOG_DEBUG("Invoking PLAT_API_GetPowerState");
+        status = PLAT_API_GetPowerState(&getState);
+        UT_LOG_DEBUG("Return powerState: %d, status: %d", getState, status);
+        UT_ASSERT_EQUAL(status, PWRMGR_SUCCESS);
+
+        UT_ASSERT_EQUAL(powerState, getState);
+    }
+
+    UT_LOG_DEBUG("Invoking PLAT_TERM");
+    status = PLAT_TERM();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, PWRMGR_SUCCESS);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test for setting and getting the wakeup source in the platform power management module
+*
+* This test verifies the functionality of the SetWakeupSrc and GetWakeupSrc functions in the platform power management module.
+* It checks if the wakeup source can be successfully set and retrieved, and if the correct status is returned for each operation.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 002@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [plat_power_L2_Low-Level_TestSpecification.md](../../docs/pages/plat_power_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_plat_power_SetAndGetWakeupSrc(void)
+{
+    gTestID = 2;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    pmStatus_t status;
+    bool enable;
+    PWRMGR_WakeupSrcType_t srcType;
+
+    UT_LOG_DEBUG("Invoking PLAT_INIT");
+    status = PLAT_INIT();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, PWRMGR_SUCCESS);
+
+    for(srcType = PWRMGR_WAKEUPSRC_VOICE; srcType < PWRMGR_WAKEUPSRC_MAX; srcType++)
+    {
+        UT_LOG_DEBUG("Invoking PLAT_API_SetWakeupSrc with srcType: %d and enable: true", srcType);
+        status = PLAT_API_SetWakeupSrc(srcType, true);
+        UT_LOG_DEBUG("Return status: %d", status);
+        UT_ASSERT_EQUAL(status, PWRMGR_SUCCESS);
+        if (status != PWRMGR_SUCCESS)
+        {
+            UT_LOG_ERROR("Failed to set Wakeup Src");
+            continue;
+        }
+
+        UT_LOG_DEBUG("Invoking PLAT_API_GetWakeupSrc with srcType: %d", srcType);
+        status = PLAT_API_GetWakeupSrc(srcType, &enable);
+        UT_LOG_DEBUG("Return status: %d, enable: %d", status, enable);
+        UT_ASSERT_EQUAL(status, PWRMGR_SUCCESS);
+        UT_ASSERT_EQUAL(enable, true);
+
+        UT_LOG_DEBUG("Invoking PLAT_API_SetWakeupSrc with srcType: %d and enable: false", srcType);
+        status = PLAT_API_SetWakeupSrc(srcType, false);
+        UT_LOG_DEBUG("Return status: %d", status);
+        UT_ASSERT_EQUAL(status, PWRMGR_SUCCESS);
+        if (status != PWRMGR_SUCCESS)
+        {
+            UT_LOG_ERROR("Failed to set Wakeup Src");
+            continue;
+        }
+
+        UT_LOG_DEBUG("Invoking PLAT_API_GetWakeupSrc with srcType: %d", srcType);
+        status = PLAT_API_GetWakeupSrc(srcType, &enable);
+        UT_LOG_DEBUG("Return status: %d, enable: %d", status, enable);
+        UT_ASSERT_EQUAL(status, PWRMGR_SUCCESS);
+        UT_ASSERT_EQUAL(enable, false);
+    }
+
+    UT_LOG_DEBUG("Invoking PLAT_TERM");
+    status = PLAT_TERM();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, PWRMGR_SUCCESS);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }
 
 static UT_test_suite_t * pSuite = NULL;
 
 /**
- * @brief Register the main test(s) for this module
+ * @brief Register the main tests for this module
  *
  * @return int - 0 on success, otherwise failure
  */
-int test_l2_plat_power_register ( void )
+
+int test_plat_power_l2_register(void)
 {
-	/* add a suite to the registry */
-	pSuite = UT_add_suite( "[L2 plat_power]", NULL, NULL );
-	if ( NULL == pSuite )
-	{
-		return -1;
-	}	
+    // Create the test suite
+    pSuite = UT_add_suite("[L2 plat_power]", NULL, NULL);
+    if (pSuite == NULL)
+    {
+        return -1;
+    }
+    // List of test function names and strings
 
-	
-	UT_add_test( pSuite, "test_l2_plat_power" ,test_l2_plat_power );
+    UT_add_test( pSuite, "l2_plat_power_SetAndGetPowerState", test_l2_plat_power_SetAndGetPowerState);
+    UT_add_test( pSuite, "l2_plat_power_SetAndGetWakeupSrc", test_l2_plat_power_SetAndGetWakeupSrc);
 
-	return 0;
-} 
-
-/** @} */ // End of PLAT_POWER_HALTEST_L2
-/** @} */ // End of POWER_MANAGER_HALTEST
-/** @} */ // End of POWER_MANAGER
-/** @} */ // End of HPK
+    return 0;
+}

--- a/src/test_register.c
+++ b/src/test_register.c
@@ -1,99 +1,30 @@
-/**
-*  If not stated otherwise in this file or this component's LICENSE
-*  file the following copyright and licenses apply:
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:*
+* Copyright 2024 RDK Management
 *
-*  Copyright 2022 RDK Management
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
 *
-*  Licensed under the Apache License, Version 2.0 (the License);
-*  you may not use this file except in compliance with the License.
-*  You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
 *
-*  http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing, software
-*  distributed under the License is distributed on an AS IS BASIS,
-*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*  See the License for the specific language governing permissions and
-*  limitations under the License.
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 */
 
-/**
- * @addtogroup HPK Hardware Porting Kit
- * @{
- * @par The Hardware Porting Kit
- * HPK is the next evolution of the well-defined Hardware Abstraction Layer
- * (HAL), but augmented with more comprehensive documentation and test suites
- * that OEM or SOC vendors can use to self-certify their ports before taking
- * them to RDKM for validation or to an operator for final integration and
- * deployment. The Hardware Porting Kit effectively enables an OEM and/or SOC
- * vendor to self-certify their own Video Accelerator devices, with minimal RDKM
- * assistance.
- *
- */
-
-/**
- * @addtogroup POWER_MANAGER Power Manager Module
- * @{
- */
-
-/**
- * @defgroup POWER_MANAGER_HALTEST Power Manager HAL Tests
- * @{
- *
- */
-
-/**
- * @addtogroup POWER_MANAGER_HALTEST_Register Power Manager HAL Tests Register File
- * @{
- * @parblock
- *
- * ### Registration of tests for Power Manager HAL :
- *
- * Registration of tests for Power Manager HAL.
- * This is to ensure that the APIs meets the operational requirements of the module across all vendors.
- *
- * **Pre-Conditions:**  None @n
- * **Dependencies:** None @n
- *
- * Refer to API Definition specification documentation : [power-manager_halSpec.md](../../docs/pages/power-manager_halSpec.md)
- *
- * @endparblock
- */
-
-/**
- * @file test_register.c
- *
- */
-
-#include <ut.h>
-
-/* L1 Testing Functions */
-extern int test_l1_plat_power_register( void );
-
-
 /* L2 Testing Functions */
-extern int test_l2_plat_power_register( void );
 
-int UT_register_APIDEF_l1_tests( void )
+extern int test_plat_power_l2_register(void);
+
+int register_hal_l2_tests( void )
 {
-	int registerFailed=0;
+    int registerFailed=0;
 
-	registerFailed |= test_l1_plat_power_register();
+    registerFailed |= test_plat_power_l2_register();
 
-	return registerFailed;
+    return registerFailed;
 }
-
-/* Register UT Functions */
-int UT_register_APIDEF_l2_tests( void )
-{
-	int registerFailed=0;
-
-	registerFailed |= test_l2_plat_power_register();
-
-	return registerFailed;
-}
-
-/** @} */ // End of PLAT_POWER_HALTEST_REGISTER
-/** @} */ // End of POWER_MANAGER_HALTEST
-/** @} */ // End of POWER_MANAGER
-/** @} */ // End of HPK


### PR DESCRIPTION
Reason for change: Generate L2 tests for Power Manager
Risks: Low
Test Procedure: Execute the hal test binary