### PR TITLE
gh #15 Code Cleanup in L1 for power_manager

### DIFF
--- a/src/test_l1_plat_power.c
+++ b/src/test_l1_plat_power.c
@@ -71,7 +71,7 @@
 #include <ut.h>
 #include <ut_log.h>
 #include "ut_kvp_profile.h"
-  
+ 
 #define POWER_MANAGER_KEY_SIZE 50
 
 static int gTestGroup = 1;
@@ -496,7 +496,7 @@ void test_l1_plat_power_positive_PLAT_API_SetWakeupSrc (void)
 
     for(int i = 0; i < countOfWakeupSources; i++){
         snprintf(keyvalue, POWER_MANAGER_KEY_SIZE, "powermanager/WakeupSources/%d", i);
-        srcType =(PWRMgr_PowerState_t)UT_KVP_PROFILE_GET_UINT32(keyvalue);
+        srcType =(PWRMGR_WakeupSrcType_t)UT_KVP_PROFILE_GET_UINT32(keyvalue);
         ret = PLAT_API_SetWakeupSrc(srcType, false);
         UT_LOG_DEBUG("Return status: %d", ret);
         if(ret == PWRMGR_OPERATION_NOT_SUPPORTED){
@@ -512,7 +512,7 @@ void test_l1_plat_power_positive_PLAT_API_SetWakeupSrc (void)
     // Step 03:Loop through all wakeup sources and set to true
     for(int i = 0; i < countOfWakeupSources; i++){
         snprintf(keyvalue, POWER_MANAGER_KEY_SIZE, "powermanager/WakeupSources/%d", i);
-        srcType =(PWRMgr_PowerState_t)UT_KVP_PROFILE_GET_UINT32(keyvalue);
+        srcType =(PWRMGR_WakeupSrcType_t)UT_KVP_PROFILE_GET_UINT32(keyvalue);
     	ret = PLAT_API_SetWakeupSrc(srcType, true);
         UT_LOG_DEBUG("Return status: %d", ret);
         if(ret == PWRMGR_OPERATION_NOT_SUPPORTED){
@@ -627,7 +627,7 @@ void test_l1_plat_power_positive_PLAT_API_GetWakeupSrc (void)
     //Step 03:Getting and setting supported wakeup sources, then verifying their states
     for(int i = 0; i < countOfWakeupSources; i++){
         snprintf(keyvalue, POWER_MANAGER_KEY_SIZE, "powermanager/WakeupSources/%d", i);
-        srcType =(PWRMgr_PowerState_t)UT_KVP_PROFILE_GET_UINT32(keyvalue);
+        srcType =(PWRMGR_WakeupSrcType_t)UT_KVP_PROFILE_GET_UINT32(keyvalue);
         UT_LOG_DEBUG("Invoking PLAT_API_SetWakeupSrc with srcType: %d and enable: true", srcType);
 
         ret = PLAT_API_SetWakeupSrc(srcType, true);

--- a/src/test_l1_plat_power.c
+++ b/src/test_l1_plat_power.c
@@ -117,11 +117,11 @@ void test_l1_plat_power_positive_PLAT_INIT (void)
 
     // Step 01: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     // Step 02: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     UT_LOG("\n Out %s\n", __FUNCTION__); 
 }
@@ -152,19 +152,19 @@ void test_l1_plat_power_negative_PLAT_INIT (void)
     gTestID = 2;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     pmStatus_t ret;
- 
+
     // Step 01: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
- 
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
+
     // Step 02: Call PLAT_INIT() - again open interface
     ret = PLAT_INIT();
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_ALREADY_INITIALIZED, PWRMGR_SUCCESS);
- 
+
     // Step 03: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
- 
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
+
     UT_LOG("\n Out %s\n", __FUNCTION__); 
 }
 
@@ -188,18 +188,18 @@ void test_l1_plat_power_negative_PLAT_INIT (void)
  * 
  */
 void test_l1_plat_power_positive_PLAT_TERM (void)
-{ 
+{
     gTestID = 3;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     pmStatus_t ret;
 
     // Step 01: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     // Step 02: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS					
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     UT_LOG("\n Out %s\n", __FUNCTION__); 
 }
@@ -238,11 +238,11 @@ void test_l1_plat_power_negative_PLAT_TERM (void)
 
     // Step 02: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     // Step 03: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     // Step 04: Call PLAT_TERM() - close interface again
     ret = PLAT_TERM();
@@ -280,25 +280,25 @@ void test_l1_plat_power_positive_PLAT_API_SetPowerState (void)
     char keyvalue[POWER_MANAGER_KEY_SIZE] = {0};
     uint8_t countOfPowerState = 0;
 
-    countOfPowerState = UT_KVP_PROFILE_GET_UINT32("powermanager/CountOfPowerState");
+    countOfPowerState = UT_KVP_PROFILE_GET_UINT8("powermanager/CountOfPowerState");
     UT_LOG_DEBUG ("Count Of Power States %d" , countOfPowerState);
 
     // Step 01: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     // step 02:Call PLAT_API_SetPowerState() -Iterate through various power states fetched from the profile file
     for(int i = 0; i < countOfPowerState; i++) {
         snprintf(keyvalue, POWER_MANAGER_KEY_SIZE, "powermanager/PowerStates/%d", i);
-        powerState = UT_KVP_PROFILE_GET_UINT32(keyvalue);
+        powerState =(PWRMgr_PowerState_t)UT_KVP_PROFILE_GET_UINT32(keyvalue);
         UT_LOG_DEBUG("Invoking PLAT_API_SetPowerState with powerState: %d", powerState);
         ret = PLAT_API_SetPowerState(powerState);
-        UT_ASSERT_EQUAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+        UT_ASSERT_EQUAL(ret, PWRMGR_SUCCESS);
     }
 
     // Step 03: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     UT_LOG("\n Out %s\n", __FUNCTION__); 
 }
@@ -337,7 +337,7 @@ void test_l1_plat_power_negative_PLAT_API_SetPowerState (void)
 
     // Step 02: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     // Step 03: Call PLAT_API_SetPowerState() - call with invalid value
     ret = PLAT_API_SetPowerState(PWRMGR_POWERSTATE_MAX);
@@ -345,7 +345,7 @@ void test_l1_plat_power_negative_PLAT_API_SetPowerState (void)
 
     // Step 04: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     // Step 05: Call PLAT_API_SetPowerState() - call after terminating the module   
     ret = PLAT_API_SetPowerState(PWRMGR_POWERSTATE_ON);
@@ -385,22 +385,22 @@ void test_l1_plat_power_positive_PLAT_API_GetPowerState (void)
 
     // Step 01: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     // Step 02: Call PLAT_API_GetPowerState() - get power state
     ret = PLAT_API_GetPowerState(&state1);
-    UT_ASSERT_EQUAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL(ret, PWRMGR_SUCCESS);
 
     // Step 03: Call PLAT_API_GetPowerState() - get power state
     ret = PLAT_API_GetPowerState(&state2);
-    UT_ASSERT_EQUAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL(ret, PWRMGR_SUCCESS);
 
     // Step 04: Verify that PLAT_API_GetPowerState() calls return the same value
-    UT_ASSERT_EQUAL(state1, state2); // Ensure both states are the same
+    UT_ASSERT_EQUAL(state1, state2);
 
     // Step 05: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
     UT_LOG("\n Out %s\n", __FUNCTION__); 
 }
 
@@ -439,7 +439,7 @@ void test_l1_plat_power_negative_PLAT_API_GetPowerState (void)
 
     // Step 02: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     // Step 03: Call PLAT_API_GetPowerState() - call with NULL pointer    
     ret = PLAT_API_GetPowerState(NULL);
@@ -447,7 +447,7 @@ void test_l1_plat_power_negative_PLAT_API_GetPowerState (void)
 
     // Step 04: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     // Step 05: Call PLAT_API_GetPowerState() - call after terminating the module    
     ret = PLAT_API_GetPowerState(&state);
@@ -488,18 +488,18 @@ void test_l1_plat_power_positive_PLAT_API_SetWakeupSrc (void)
 
     // Step 01: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     // Step 02:Loop through all wakeup sources and set to false
-    countOfWakeupSources = UT_KVP_PROFILE_GET_UINT32("powermanager/CountOfWakeupSources");
+    countOfWakeupSources = UT_KVP_PROFILE_GET_UINT8("powermanager/CountOfWakeupSources");
     UT_LOG_DEBUG ("Count Of Wakeup Sources %d" , countOfWakeupSources);
- 
+
     for(int i = 0; i < countOfWakeupSources; i++){
         snprintf(keyvalue, POWER_MANAGER_KEY_SIZE, "powermanager/WakeupSources/%d", i);
-        srcType = UT_KVP_PROFILE_GET_UINT32(keyvalue);
+        srcType =(PWRMgr_PowerState_t)UT_KVP_PROFILE_GET_UINT32(keyvalue);
         ret = PLAT_API_SetWakeupSrc(srcType, false);
         UT_LOG_DEBUG("Return status: %d", ret);
-        if(ret == PWRMGR_OPERATION_NOT_SUPPORTED){// Check for operation not supported case
+        if(ret == PWRMGR_OPERATION_NOT_SUPPORTED){
        
             UT_LOG("\n Function: %s Wake up source is not supported\n", __FUNCTION__);
         }
@@ -512,10 +512,10 @@ void test_l1_plat_power_positive_PLAT_API_SetWakeupSrc (void)
     // Step 03:Loop through all wakeup sources and set to true
     for(int i = 0; i < countOfWakeupSources; i++){
         snprintf(keyvalue, POWER_MANAGER_KEY_SIZE, "powermanager/WakeupSources/%d", i);
-        srcType = UT_KVP_PROFILE_GET_UINT32(keyvalue);
+        srcType =(PWRMgr_PowerState_t)UT_KVP_PROFILE_GET_UINT32(keyvalue);
     	ret = PLAT_API_SetWakeupSrc(srcType, true);
         UT_LOG_DEBUG("Return status: %d", ret);
-        if(ret == PWRMGR_OPERATION_NOT_SUPPORTED){// Check for operation not supported case
+        if(ret == PWRMGR_OPERATION_NOT_SUPPORTED){
            
             UT_LOG("\n Function: %s Wake up source is not supported\n", __FUNCTION__);
         } 
@@ -527,8 +527,8 @@ void test_l1_plat_power_positive_PLAT_API_SetWakeupSrc (void)
 
     // Step 4: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
- 
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
+
     UT_LOG("\n Out %s\n", __FUNCTION__); 
 }
 
@@ -566,7 +566,7 @@ void test_l1_plat_power_negative_PLAT_API_SetWakeupSrc (void)
 
     // Step 02: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     // Step 03: Call PLAT_API_SetWakeupSrc() - call with invalid value
     ret = PLAT_API_SetWakeupSrc(PWRMGR_WAKEUPSRC_MAX, false);
@@ -574,7 +574,7 @@ void test_l1_plat_power_negative_PLAT_API_SetWakeupSrc (void)
 
     // Step 04: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     // Step 05: Call PLAT_API_SetWakeupSrc() - call after terminating the module
     ret = PLAT_API_SetWakeupSrc(PWRMGR_WAKEUPSRC_IR, false);
@@ -621,13 +621,13 @@ void test_l1_plat_power_positive_PLAT_API_GetWakeupSrc (void)
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     //Step 02:Getting the count of the supported wakeup sources
-    countOfWakeupSources = UT_KVP_PROFILE_GET_UINT32("powermanager/CountOfWakeupSources");
+    countOfWakeupSources = UT_KVP_PROFILE_GET_UINT8("powermanager/CountOfWakeupSources");
     UT_LOG_DEBUG ("Count Of Wakeup Sources %d" , countOfWakeupSources);
 
     //Step 03:Getting and setting supported wakeup sources, then verifying their states
     for(int i = 0; i < countOfWakeupSources; i++){
         snprintf(keyvalue, POWER_MANAGER_KEY_SIZE, "powermanager/WakeupSources/%d", i);
-        srcType = UT_KVP_PROFILE_GET_UINT32(keyvalue);
+        srcType =(PWRMgr_PowerState_t)UT_KVP_PROFILE_GET_UINT32(keyvalue);
         UT_LOG_DEBUG("Invoking PLAT_API_SetWakeupSrc with srcType: %d and enable: true", srcType);
 
         ret = PLAT_API_SetWakeupSrc(srcType, true);
@@ -703,7 +703,7 @@ void test_l1_plat_power_negative_PLAT_API_GetWakeupSrc (void)
  
     // Step 02: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     // Step 03: Call PLAT_API_GetWakeupSrc() - call with NULL pointer    
     ret = PLAT_API_GetWakeupSrc(srcType, NULL);
@@ -711,8 +711,8 @@ void test_l1_plat_power_negative_PLAT_API_GetWakeupSrc (void)
 
     // Step 04: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
- 
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
+
     // Step 05: Call PLAT_API_GetWakeupSrc() - call after terminating the module
     ret = PLAT_API_GetWakeupSrc(srcType, &enable);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
@@ -750,19 +750,19 @@ void test_l1_plat_power_positive_PLAT_Reset (void)
     char keyvalue[POWER_MANAGER_KEY_SIZE] = {0};
     uint8_t countOfPowerState = 0;
     PWRMgr_PowerState_t powerState;
- 
+
     // Step 1: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     //Step 02:Getting the count of the power states
-    countOfPowerState = UT_KVP_PROFILE_GET_UINT32("powermanager/CountOfPowerState");
+    countOfPowerState = UT_KVP_PROFILE_GET_UINT8("powermanager/CountOfPowerState");
     UT_LOG_DEBUG ("Count Of Power States %d" , countOfPowerState);
 
     // Step 03: Loop over each power state and call PLAT_Reset()
     for(int i = 0; i < countOfPowerState; i++) {
 	snprintf(keyvalue, POWER_MANAGER_KEY_SIZE, "powermanager/PowerStates/%d", i);
-        powerState = UT_KVP_PROFILE_GET_UINT32(keyvalue);
+        powerState =(PWRMgr_PowerState_t)UT_KVP_PROFILE_GET_UINT32(keyvalue);
         UT_LOG_DEBUG("Invoking PLAT_API_SetPowerState with powerState: %d", powerState);
         ret = PLAT_Reset(powerState);
         UT_ASSERT_EQUAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
@@ -770,7 +770,7 @@ void test_l1_plat_power_positive_PLAT_Reset (void)
 
     // Step 04: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     UT_LOG("\n Out %s\n", __FUNCTION__); 
 }
@@ -810,15 +810,15 @@ void test_l1_plat_power_negative_PLAT_Reset (void)
 
     // Step 02: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     // Step 03: Call PLAT_Reset() - call with invalid value   
     ret = PLAT_Reset(PWRMGR_POWERSTATE_MAX);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_INVALID_ARGUMENT, PWRMGR_SUCCESS);
- 
+
     // Step 04: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
     // Step 05: Call PLAT_Reset() - call after terminating the module    
     ret = PLAT_Reset(PWRMGR_POWERSTATE_ON);
@@ -840,7 +840,7 @@ int test_l1_plat_power_register ( void )
     pSuite = UT_add_suite( "[L1 plat_power]", NULL, NULL );
     if ( NULL == pSuite )
     {
-	return -1;
+        return -1;
     }	
 
     UT_add_test( pSuite, "PLAT_INIT_L1_positive" ,test_l1_plat_power_positive_PLAT_INIT );

--- a/src/test_l1_plat_power.c
+++ b/src/test_l1_plat_power.c
@@ -71,7 +71,7 @@
 #include <ut.h>
 #include <ut_log.h>
 #include "ut_kvp_profile.h"
- 
+
 #define POWER_MANAGER_KEY_SIZE 50
 
 static int gTestGroup = 1;

--- a/src/test_l1_plat_power.c
+++ b/src/test_l1_plat_power.c
@@ -71,7 +71,7 @@
 #include <ut.h>
 #include <ut_log.h>
 #include "ut_kvp_profile.h"
-
+   
 #define POWER_MANAGER_KEY_SIZE 50
 
 static int gTestGroup = 1;
@@ -89,7 +89,7 @@ static bool extendedEnumsSupported=false;
        UT_ASSERT_EQUAL( old, result );\
    }\
 }
-
+ 
 /**
  * @brief Ensure PLAT_INIT() returns correct error codes during positive scenarios
  * 
@@ -115,11 +115,11 @@ void test_l1_plat_power_positive_PLAT_INIT (void)
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
     pmStatus_t ret;
 
-    // Variation/Step 01: Call PLAT_INIT() - open interface
+    // Step 01: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
 
-    // Variation/Step 02: Call PLAT_TERM() - close interface
+    // Step 02: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
 
@@ -131,8 +131,7 @@ void test_l1_plat_power_positive_PLAT_INIT (void)
  * 
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 002@n
- * 
- * 
+ *  
  * **Pre-Conditions:**@n
  * None.
  * 
@@ -146,7 +145,6 @@ void test_l1_plat_power_positive_PLAT_INIT (void)
  * |02|Call PLAT_INIT() - again open interface | | PWRMGR_ALREADY_INITIALIZED | Should Pass |
  * |03|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
  * 
- * 
  * @note The error code PWRMGR_INIT_FAILURE is not able to be tested here.
  */
 void test_l1_plat_power_negative_PLAT_INIT (void)
@@ -154,19 +152,19 @@ void test_l1_plat_power_negative_PLAT_INIT (void)
     gTestID = 2;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     pmStatus_t ret;
-
-    // Variation/Step 01: Call PLAT_INIT() - open interface
+ 
+    // Step 01: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
-
-    // Variation/Step 02: Call PLAT_INIT() - again open interface
+ 
+    // Step 02: Call PLAT_INIT() - again open interface
     ret = PLAT_INIT();
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_ALREADY_INITIALIZED, PWRMGR_SUCCESS);
  
-    // Variation/Step 03: Call PLAT_TERM() - close interface
+    // Step 03: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
-
+ 
     UT_LOG("\n Out %s\n", __FUNCTION__); 
 }
 
@@ -190,18 +188,19 @@ void test_l1_plat_power_negative_PLAT_INIT (void)
  * 
  */
 void test_l1_plat_power_positive_PLAT_TERM (void)
-{
+{ 
     gTestID = 3;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     pmStatus_t ret;
 
-    // Variation/Step 01: Call PLAT_INIT() - open interface
+    // Step 01: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
 
-    // Variation/Step 02: Call PLAT_TERM() - close interface
+    // Step 02: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
-    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+    UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS					
+
     UT_LOG("\n Out %s\n", __FUNCTION__); 
 }
 
@@ -233,19 +232,19 @@ void test_l1_plat_power_negative_PLAT_TERM (void)
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     pmStatus_t ret;
 
-    // Variation/Step 01: Call PLAT_TERM() - close interface without initializing
+    // Step 01: Call PLAT_TERM() - close interface without initializing
     ret = PLAT_TERM();
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
-    
-    // Variation/Step 02: Call PLAT_INIT() - open interface
+
+    // Step 02: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
 
-    // Variation/Step 03: Call PLAT_TERM() - close interface
+    // Step 03: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
 
-    // Variation/Step 04: Call PLAT_TERM() - close interface again
+    // Step 04: Call PLAT_TERM() - close interface again
     ret = PLAT_TERM();
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
 
@@ -284,22 +283,23 @@ void test_l1_plat_power_positive_PLAT_API_SetPowerState (void)
     countOfPowerState = UT_KVP_PROFILE_GET_UINT32("powermanager/CountOfPowerState");
     UT_LOG_DEBUG ("Count Of Power States %d" , countOfPowerState);
 
-    // Variation/Step 01: Call PLAT_INIT() - open interface
+    // Step 01: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
 
-    // Variation/step 02:Call PLAT_API_SetPowerState() -Iterate through various power states fetched from the profile file
+    // step 02:Call PLAT_API_SetPowerState() -Iterate through various power states fetched from the profile file
     for(int i = 0; i < countOfPowerState; i++) {
         snprintf(keyvalue, POWER_MANAGER_KEY_SIZE, "powermanager/PowerStates/%d", i);
         powerState = UT_KVP_PROFILE_GET_UINT32(keyvalue);
-	UT_LOG_DEBUG("Invoking PLAT_API_SetPowerState with powerState: %d", powerState);
+        UT_LOG_DEBUG("Invoking PLAT_API_SetPowerState with powerState: %d", powerState);
         ret = PLAT_API_SetPowerState(powerState);
         UT_ASSERT_EQUAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
     }
 
-    // Variation/Step 03: Call PLAT_TERM() - close interface
+    // Step 03: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+
     UT_LOG("\n Out %s\n", __FUNCTION__); 
 }
 
@@ -322,8 +322,7 @@ void test_l1_plat_power_positive_PLAT_API_SetPowerState (void)
  * |03|Call PLAT_API_SetPowerState() - call with invalid value | newState=PWRMGR_POWERSTATE_MAX | PWRMGR_INVALID_ARGUMENT | Should Pass |
  * |04|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
  * |05|Call PLAT_API_SetPowerState() - call after terminating the module | newState=PWRMGR_POWERSTATE_ON | PWRMGR_NOT_INITIALIZED | Should Pass |
- * 
- * 
+ *  
  * @note The error code PWRMGR_SET_FAILURE is not able to be tested here.
  */
 void test_l1_plat_power_negative_PLAT_API_SetPowerState (void)
@@ -332,23 +331,23 @@ void test_l1_plat_power_negative_PLAT_API_SetPowerState (void)
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     pmStatus_t ret;
 
-    // Variation/Step 01: Call PLAT_API_SetPowerState() - call without initializing the module
+    // Step 01: Call PLAT_API_SetPowerState() - call without initializing the module
     ret = PLAT_API_SetPowerState(PWRMGR_POWERSTATE_ON);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
 
-    // Variation/Step 02: Call PLAT_INIT() - open interface
+    // Step 02: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
 
-    // Variation/Step 03: Call PLAT_API_SetPowerState() - call with invalid value
+    // Step 03: Call PLAT_API_SetPowerState() - call with invalid value
     ret = PLAT_API_SetPowerState(PWRMGR_POWERSTATE_MAX);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_INVALID_ARGUMENT, PWRMGR_SUCCESS);
 
-    // Variation/Step 04: Call PLAT_TERM() - close interface
+    // Step 04: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
 
-    // Variation/Step 05: Call PLAT_API_SetPowerState() - call after terminating the module   
+    // Step 05: Call PLAT_API_SetPowerState() - call after terminating the module   
     ret = PLAT_API_SetPowerState(PWRMGR_POWERSTATE_ON);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
 
@@ -360,7 +359,6 @@ void test_l1_plat_power_negative_PLAT_API_SetPowerState (void)
  * 
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 007@n
- * 
  * 
  * **Pre-Conditions:**@n
  * None.
@@ -385,22 +383,22 @@ void test_l1_plat_power_positive_PLAT_API_GetPowerState (void)
     pmStatus_t ret;
     PWRMgr_PowerState_t state1, state2;
 
-    // Variation/Step 01: Call PLAT_INIT() - open interface
+    // Step 01: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
 
-    // Variation/Step 02: Call PLAT_API_GetPowerState() - get power state
+    // Step 02: Call PLAT_API_GetPowerState() - get power state
     ret = PLAT_API_GetPowerState(&state1);
     UT_ASSERT_EQUAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
 
-    // Variation/Step 03: Call PLAT_API_GetPowerState() - get power state
+    // Step 03: Call PLAT_API_GetPowerState() - get power state
     ret = PLAT_API_GetPowerState(&state2);
     UT_ASSERT_EQUAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
 
-    // Variation/Step 04: Verify that PLAT_API_GetPowerState() calls return the same value
+    // Step 04: Verify that PLAT_API_GetPowerState() calls return the same value
     UT_ASSERT_EQUAL(state1, state2); // Ensure both states are the same
 
-    // Variation/Step 05: Call PLAT_TERM() - close interface
+    // Step 05: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
     UT_LOG("\n Out %s\n", __FUNCTION__); 
@@ -425,37 +423,36 @@ void test_l1_plat_power_positive_PLAT_API_GetPowerState (void)
  * |03|Call PLAT_API_GetPowerState() - call with NULL pointer | curState*=NULL | PWRMGR_INVALID_ARGUMENT | Should Pass |
  * |04|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
  * |05|Call PLAT_API_GetPowerState() - call after terminating the module | curState* | PWRMGR_NOT_INITIALIZED | Should Pass |
- * 
- * 
+ *  
  * @note The error code PWRMGR_GET_FAILURE is not able to be tested here.
  */
 void test_l1_plat_power_negative_PLAT_API_GetPowerState (void)
-{
+{  
     gTestID = 8;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     pmStatus_t ret;
     PWRMgr_PowerState_t state;
 
-    // Variation/Step 01: Call PLAT_API_GetPowerState() - call without initializing the module
+    // Step 01: Call PLAT_API_GetPowerState() - call without initializing the module
     ret = PLAT_API_GetPowerState(&state);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
 
-    // Variation/Step 02: Call PLAT_INIT() - open interface
+    // Step 02: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
 
-    // Variation/Step 03: Call PLAT_API_GetPowerState() - call with NULL pointer    
+    // Step 03: Call PLAT_API_GetPowerState() - call with NULL pointer    
     ret = PLAT_API_GetPowerState(NULL);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_INVALID_ARGUMENT, PWRMGR_SUCCESS);
 
-    // Variation/Step 04: Call PLAT_TERM() - close interface
+    // Step 04: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
 
-    // Variation/Step 05: Call PLAT_API_GetPowerState() - call after terminating the module    
+    // Step 05: Call PLAT_API_GetPowerState() - call after terminating the module    
     ret = PLAT_API_GetPowerState(&state);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
-   
+
     UT_LOG("\n Out %s\n", __FUNCTION__); 
 }
 
@@ -475,8 +472,8 @@ void test_l1_plat_power_negative_PLAT_API_GetPowerState (void)
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|---------|----------|--------------|-----|
  * |01|Call PLAT_INIT() - open interface | | PWRMGR_SUCCESS | Should Pass |
- * |02|Call PLAT_API_SetWakeupSrc() - Loop through all PWRMGR_WakeupSrcType_t and set to false| srcType=PWRMGR_WAKEUPSRC_MAX, enabled=false | PWRMGR_SUCCESS | Should Pass |
- * |03|Call PLAT_API_SetWakeupSrc() - Loop through all PWRMGR_WakeupSrcType_t and set to true| srcType=PWRMGR_WAKEUPSRC_MAX, enabled=true | PWRMGR_SUCCESS | Should Pass |
+ * |02|Call PLAT_API_SetWakeupSrc() - Loop through all wakeup sources and set to false| srcType=PWRMGR_WAKEUPSRC_MAX, enabled=false | PWRMGR_SUCCESS | Should Pass |
+ * |03|Call PLAT_API_SetWakeupSrc() - Loop through all wakeup sources and set to true| srcType=PWRMGR_WAKEUPSRC_MAX, enabled=true | PWRMGR_SUCCESS | Should Pass |
  * |04|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
  * 
  */
@@ -489,48 +486,49 @@ void test_l1_plat_power_positive_PLAT_API_SetWakeupSrc (void)
     char keyvalue[POWER_MANAGER_KEY_SIZE] = {0};
     uint8_t countOfWakeupSources = 0;
 
-    // Variation/Step 01: Call PLAT_INIT() - open interface
+    // Step 01: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
 
-    // Variation/Step 02:Loop through all wakeup sources and set to false
+    // Step 02:Loop through all wakeup sources and set to false
     countOfWakeupSources = UT_KVP_PROFILE_GET_UINT32("powermanager/CountOfWakeupSources");
     UT_LOG_DEBUG ("Count Of Wakeup Sources %d" , countOfWakeupSources);
-    
+ 
     for(int i = 0; i < countOfWakeupSources; i++){
         snprintf(keyvalue, POWER_MANAGER_KEY_SIZE, "powermanager/WakeupSources/%d", i);
         srcType = UT_KVP_PROFILE_GET_UINT32(keyvalue);
         ret = PLAT_API_SetWakeupSrc(srcType, false);
         UT_LOG_DEBUG("Return status: %d", ret);
         if(ret == PWRMGR_OPERATION_NOT_SUPPORTED){// Check for operation not supported case
-           // UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_OPERATION_NOT_SUPPORTED)
+       
             UT_LOG("\n Function: %s Wake up source is not supported\n", __FUNCTION__);
         }
         else{
             UT_ASSERT_EQUAL(ret, PWRMGR_SUCCESS);
         }
-
+    
     }
 
-    // Variation/Step 03:Loop through all wakeup sources and set to true
+    // Step 03:Loop through all wakeup sources and set to true
     for(int i = 0; i < countOfWakeupSources; i++){
         snprintf(keyvalue, POWER_MANAGER_KEY_SIZE, "powermanager/WakeupSources/%d", i);
         srcType = UT_KVP_PROFILE_GET_UINT32(keyvalue);
-	ret = PLAT_API_SetWakeupSrc(srcType, true);
+    	ret = PLAT_API_SetWakeupSrc(srcType, true);
         UT_LOG_DEBUG("Return status: %d", ret);
         if(ret == PWRMGR_OPERATION_NOT_SUPPORTED){// Check for operation not supported case
-           // UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_OPERATION_NOT_SUPPORTED)
+           
             UT_LOG("\n Function: %s Wake up source is not supported\n", __FUNCTION__);
         } 
         else{
             UT_ASSERT_EQUAL(ret, PWRMGR_SUCCESS);
         }
-
+    
     }
 
-    // Variation/Step 4: Call PLAT_TERM() - close interface
+    // Step 4: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+ 
     UT_LOG("\n Out %s\n", __FUNCTION__); 
 }
 
@@ -562,23 +560,23 @@ void test_l1_plat_power_negative_PLAT_API_SetWakeupSrc (void)
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     pmStatus_t ret;
 
-    // Variation/Step 01: Call PLAT_API_SetWakeupSrc() - call without initializing the module
+    // Step 01: Call PLAT_API_SetWakeupSrc() - call without initializing the module
     ret = PLAT_API_SetWakeupSrc(PWRMGR_WAKEUPSRC_IR, false);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
-    
-    // Variation/Step 02: Call PLAT_INIT() - open interface
+
+    // Step 02: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
 
-    // Variation/Step 03: Call PLAT_API_SetWakeupSrc() - call with invalid value
+    // Step 03: Call PLAT_API_SetWakeupSrc() - call with invalid value
     ret = PLAT_API_SetWakeupSrc(PWRMGR_WAKEUPSRC_MAX, false);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_INVALID_ARGUMENT, PWRMGR_SUCCESS);
 
-    // Variation/Step 04: Call PLAT_TERM() - close interface
+    // Step 04: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
 
-    // Variation/Step 05: Call PLAT_API_SetWakeupSrc() - call after terminating the module
+    // Step 05: Call PLAT_API_SetWakeupSrc() - call after terminating the module
     ret = PLAT_API_SetWakeupSrc(PWRMGR_WAKEUPSRC_IR, false);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
 
@@ -603,8 +601,8 @@ void test_l1_plat_power_negative_PLAT_API_SetWakeupSrc (void)
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|---------|----------|--------------|-----|
  * |01|Call PLAT_INIT() - open interface | | PWRMGR_SUCCESS | Should Pass |
- * |02|Call PLAT_API_GetWakeupSrc() - Loop through get PWRMGR_WakeupSrcType_t and call the last value twice | srcType=PWRMGR_WAKEUPSRC_MAX, *enable| PWRMGR_SUCCESS | Should Pass |
- * |03|Verify that PLAT_API_GetWakeupSrc() returns the same values upon return | | | Should Pass |
+ * |02|Retrieve the count of supported wakeup sources from the profile file
+ * |03|Call PLAT_API_GetWakeupSrc() - Retrieve and set each supported wakeup source, then get and verify its state | srcType=PWRMGR_WAKEUPSRC_MAX, *enable| PWRMGR_SUCCESS | Should Pass |
  * |04|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
  * 
  */
@@ -626,7 +624,7 @@ void test_l1_plat_power_positive_PLAT_API_GetWakeupSrc (void)
     countOfWakeupSources = UT_KVP_PROFILE_GET_UINT32("powermanager/CountOfWakeupSources");
     UT_LOG_DEBUG ("Count Of Wakeup Sources %d" , countOfWakeupSources);
 
-    //Step 03:Getting the supported wakeup sources
+    //Step 03:Getting and setting supported wakeup sources, then verifying their states
     for(int i = 0; i < countOfWakeupSources; i++){
         snprintf(keyvalue, POWER_MANAGER_KEY_SIZE, "powermanager/WakeupSources/%d", i);
         srcType = UT_KVP_PROFILE_GET_UINT32(keyvalue);
@@ -665,6 +663,7 @@ void test_l1_plat_power_positive_PLAT_API_GetWakeupSrc (void)
     // Step 04: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
+
     UT_LOG("\n Out %s\n", __FUNCTION__); 
 }
 
@@ -688,7 +687,6 @@ void test_l1_plat_power_positive_PLAT_API_GetWakeupSrc (void)
  * |04|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
  * |05|Call PLAT_API_GetWakeupSrc() - call after terminating the module | srcType, *enable | PWRMGR_NOT_INITIALIZED | Should Pass |
  * 
- * 
  * @note The error code PWRMGR_GET_FAILURE is not able to be tested here.
  */
 void test_l1_plat_power_negative_PLAT_API_GetWakeupSrc (void)
@@ -697,25 +695,25 @@ void test_l1_plat_power_negative_PLAT_API_GetWakeupSrc (void)
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     pmStatus_t ret;
     bool enable;
-    PWRMGR_WakeupSrcType_t srcType = PWRMGR_WAKEUPSRC_IR; // You can choose any valid srcType for this test
+    PWRMGR_WakeupSrcType_t srcType = PWRMGR_WAKEUPSRC_IR; 
 
-    // Variation/Step 01: Call PLAT_API_GetWakeupSrc() - call without initializing the module
+    // Step 01: Call PLAT_API_GetWakeupSrc() - call without initializing the module
     ret = PLAT_API_GetWakeupSrc(srcType, &enable);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
-
-    // Variation/Step 02: Call PLAT_INIT() - open interface
+ 
+    // Step 02: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
 
-    // Variation/Step 03: Call PLAT_API_GetWakeupSrc() - call with NULL pointer    
+    // Step 03: Call PLAT_API_GetWakeupSrc() - call with NULL pointer    
     ret = PLAT_API_GetWakeupSrc(srcType, NULL);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_INVALID_ARGUMENT, PWRMGR_SUCCESS);
 
-    // Variation/Step 04: Call PLAT_TERM() - close interface
+    // Step 04: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
-
-    // Variation/Step 05: Call PLAT_API_GetWakeupSrc() - call after terminating the module
+ 
+    // Step 05: Call PLAT_API_GetWakeupSrc() - call after terminating the module
     ret = PLAT_API_GetWakeupSrc(srcType, &enable);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
 
@@ -738,8 +736,9 @@ void test_l1_plat_power_negative_PLAT_API_GetWakeupSrc (void)
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|---------|----------|--------------|-----|
  * |01|Call PLAT_INIT() - open interface | | PWRMGR_SUCCESS | Should Pass |
- * |02|Call PLAT_Reset() - Loop through PWRMgr_PowerState_t as input value | newState=PWRMGR_POWERSTATE_STANDBY_DEEP_SLEEP | PWRMGR_SUCCESS | Should Pass |
- * |03|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
+ * |02|Retrieve the count of power states from the profile file   
+ * |03|Call PLAT_Reset() - Loop over each power state and call PLAT_Reset() | newState=PWRMGR_POWERSTATE_STANDBY_DEEP_SLEEP | PWRMGR_SUCCESS | Should Pass |
+ * |04|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
  * 
  * @note This test case is deprecated.
  */
@@ -751,15 +750,16 @@ void test_l1_plat_power_positive_PLAT_Reset (void)
     char keyvalue[POWER_MANAGER_KEY_SIZE] = {0};
     uint8_t countOfPowerState = 0;
     PWRMgr_PowerState_t powerState;
-
-    countOfPowerState = UT_KVP_PROFILE_GET_UINT32("powermanager/CountOfPowerState");
-    UT_LOG_DEBUG ("Count Of Power States %d" , countOfPowerState);
-
-    // Step 01: Call PLAT_INIT() - open interface
+ 
+    // Step 1: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
-    // Step 02: Loop over each power state and call PLAT_Reset()
+    //Step 02:Getting the count of the power states
+    countOfPowerState = UT_KVP_PROFILE_GET_UINT32("powermanager/CountOfPowerState");
+    UT_LOG_DEBUG ("Count Of Power States %d" , countOfPowerState);
+
+    // Step 03: Loop over each power state and call PLAT_Reset()
     for(int i = 0; i < countOfPowerState; i++) {
 	snprintf(keyvalue, POWER_MANAGER_KEY_SIZE, "powermanager/PowerStates/%d", i);
         powerState = UT_KVP_PROFILE_GET_UINT32(keyvalue);
@@ -768,9 +768,10 @@ void test_l1_plat_power_positive_PLAT_Reset (void)
         UT_ASSERT_EQUAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
     }
 
-    // Step 03: Call PLAT_TERM() - close interface
+    // Step 04: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
+
     UT_LOG("\n Out %s\n", __FUNCTION__); 
 }
 
@@ -802,7 +803,7 @@ void test_l1_plat_power_negative_PLAT_Reset (void)
     gTestID = 14;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     pmStatus_t ret;
-    
+ 
     // Step 01: Call PLAT_Reset() - call without initializing the module
     ret = PLAT_Reset(PWRMGR_POWERSTATE_ON);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
@@ -814,7 +815,7 @@ void test_l1_plat_power_negative_PLAT_Reset (void)
     // Step 03: Call PLAT_Reset() - call with invalid value   
     ret = PLAT_Reset(PWRMGR_POWERSTATE_MAX);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_INVALID_ARGUMENT, PWRMGR_SUCCESS);
-
+ 
     // Step 04: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS); // Ensure the returned value is PWRMGR_SUCCESS
@@ -835,30 +836,30 @@ static UT_test_suite_t * pSuite = NULL;
  */
 int test_l1_plat_power_register ( void )
 {
-	/* add a suite to the registry */
-	pSuite = UT_add_suite( "[L1 plat_power]", NULL, NULL );
-	if ( NULL == pSuite )
-	{
-		return -1;
-	}	
+    /* add a suite to the registry */
+    pSuite = UT_add_suite( "[L1 plat_power]", NULL, NULL );
+    if ( NULL == pSuite )
+    {
+	return -1;
+    }	
 
-	UT_add_test( pSuite, "PLAT_INIT_L1_positive" ,test_l1_plat_power_positive_PLAT_INIT );
-	UT_add_test( pSuite, "PLAT_INIT_L1_negative" ,test_l1_plat_power_negative_PLAT_INIT );
-        UT_add_test( pSuite, "PLAT_TERM_L1_positive" ,test_l1_plat_power_positive_PLAT_TERM );
-	UT_add_test( pSuite, "PLAT_TERM_L1_negative" ,test_l1_plat_power_negative_PLAT_TERM );
-	UT_add_test( pSuite, "PLAT_API_SetPowerState_L1_positive" ,test_l1_plat_power_positive_PLAT_API_SetPowerState );
-	UT_add_test( pSuite, "PLAT_API_SetPowerState_L1_negative" ,test_l1_plat_power_negative_PLAT_API_SetPowerState );
-	UT_add_test( pSuite, "PLAT_API_GetPowerState_L1_positive" ,test_l1_plat_power_positive_PLAT_API_GetPowerState );
-	UT_add_test( pSuite, "PLAT_API_GetPowerState_L1_negative" ,test_l1_plat_power_negative_PLAT_API_GetPowerState );
-	UT_add_test( pSuite, "PLAT_API_SetWakeupSrc_L1_positive" ,test_l1_plat_power_positive_PLAT_API_SetWakeupSrc );
-	UT_add_test( pSuite, "PLAT_API_SetWakeupSrc_L1_negative" ,test_l1_plat_power_negative_PLAT_API_SetWakeupSrc );
-	UT_add_test( pSuite, "PLAT_API_GetWakeupSrc_L1_positive" ,test_l1_plat_power_positive_PLAT_API_GetWakeupSrc );
-	UT_add_test( pSuite, "PLAT_API_GetWakeupSrc_L1_negative" ,test_l1_plat_power_negative_PLAT_API_GetWakeupSrc );
-	UT_add_test( pSuite, "PLAT_Reset_L1_positive" ,test_l1_plat_power_positive_PLAT_Reset );
-	UT_add_test( pSuite, "PLAT_Reset_L1_negative" ,test_l1_plat_power_negative_PLAT_Reset );
-        extendedEnumsSupported = ut_kvp_getBoolField( ut_kvp_profile_getInstance(), "powermanager/features/extendedEnumsSupported" );	
+    UT_add_test( pSuite, "PLAT_INIT_L1_positive" ,test_l1_plat_power_positive_PLAT_INIT );
+    UT_add_test( pSuite, "PLAT_INIT_L1_negative" ,test_l1_plat_power_negative_PLAT_INIT );
+    UT_add_test( pSuite, "PLAT_TERM_L1_positive" ,test_l1_plat_power_positive_PLAT_TERM );
+    UT_add_test( pSuite, "PLAT_TERM_L1_negative" ,test_l1_plat_power_negative_PLAT_TERM );
+    UT_add_test( pSuite, "PLAT_API_SetPowerState_L1_positive" ,test_l1_plat_power_positive_PLAT_API_SetPowerState );
+    UT_add_test( pSuite, "PLAT_API_SetPowerState_L1_negative" ,test_l1_plat_power_negative_PLAT_API_SetPowerState );
+    UT_add_test( pSuite, "PLAT_API_GetPowerState_L1_positive" ,test_l1_plat_power_positive_PLAT_API_GetPowerState );
+    UT_add_test( pSuite, "PLAT_API_GetPowerState_L1_negative" ,test_l1_plat_power_negative_PLAT_API_GetPowerState );
+    UT_add_test( pSuite, "PLAT_API_SetWakeupSrc_L1_positive" ,test_l1_plat_power_positive_PLAT_API_SetWakeupSrc );
+    UT_add_test( pSuite, "PLAT_API_SetWakeupSrc_L1_negative" ,test_l1_plat_power_negative_PLAT_API_SetWakeupSrc );
+    UT_add_test( pSuite, "PLAT_API_GetWakeupSrc_L1_positive" ,test_l1_plat_power_positive_PLAT_API_GetWakeupSrc );
+    UT_add_test( pSuite, "PLAT_API_GetWakeupSrc_L1_negative" ,test_l1_plat_power_negative_PLAT_API_GetWakeupSrc );
+    UT_add_test( pSuite, "PLAT_Reset_L1_positive" ,test_l1_plat_power_positive_PLAT_Reset );
+    UT_add_test( pSuite, "PLAT_Reset_L1_negative" ,test_l1_plat_power_negative_PLAT_Reset );
+    extendedEnumsSupported = ut_kvp_getBoolField( ut_kvp_profile_getInstance(), "powermanager/features/extendedEnumsSupported" );	
 
-	return 0;
+    return 0;
 } 
 /** @} */ // End of PLAT_POWER_HALTEST_L1
 /** @} */ // End of POWER_MANAGER_HALTEST

--- a/src/test_l1_plat_power.c
+++ b/src/test_l1_plat_power.c
@@ -71,12 +71,12 @@
 #include <ut.h>
 #include <ut_log.h>
 #include "ut_kvp_profile.h"
-   
+  
 #define POWER_MANAGER_KEY_SIZE 50
 
 static int gTestGroup = 1;
 static int gTestID = 1;
-static bool extendedEnumsSupported=false; 
+static bool extendedEnumsSupported=false;
 
 #define CHECK_FOR_EXTENDED_ERROR_CODE( result, enhanced, old )\
 {\
@@ -89,25 +89,25 @@ static bool extendedEnumsSupported=false;
        UT_ASSERT_EQUAL( old, result );\
    }\
 }
- 
+
 /**
  * @brief Ensure PLAT_INIT() returns correct error codes during positive scenarios
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 001@n
- * 
+ *
  * **Pre-Conditions:**@n
  * None.
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|---------|----------|--------------|-----|
  * |01|Call PLAT_INIT() - open interface | | PWRMGR_SUCCESS | Should Pass |
  * |02|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
- * 
+ *
  */
 void test_l1_plat_power_positive_PLAT_INIT (void)
 {
@@ -123,28 +123,28 @@ void test_l1_plat_power_positive_PLAT_INIT (void)
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure PLAT_INIT() returns correct error codes during negative scenarios
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 002@n
- *  
+ * 
  * **Pre-Conditions:**@n
  * None.
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|---------|----------|--------------|-----|
  * |01|Call PLAT_INIT() - open interface | | PWRMGR_SUCCESS | Should Pass |
  * |02|Call PLAT_INIT() - again open interface | | PWRMGR_ALREADY_INITIALIZED | Should Pass |
  * |03|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
- * 
+ *
  * @note The error code PWRMGR_INIT_FAILURE is not able to be tested here.
  */
 void test_l1_plat_power_negative_PLAT_INIT (void)
@@ -165,27 +165,27 @@ void test_l1_plat_power_negative_PLAT_INIT (void)
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure PLAT_TERM() returns correct error codes during positive scenarios
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 003@n
- * 
+ *
  * **Pre-Conditions:**@n
  * None.
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|---------|----------|--------------|-----|
  * |01|Call PLAT_INIT() - open interface | | PWRMGR_SUCCESS | Should Pass |
  * |02|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
- * 
+ *
  */
 void test_l1_plat_power_positive_PLAT_TERM (void)
 {
@@ -201,21 +201,21 @@ void test_l1_plat_power_positive_PLAT_TERM (void)
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure PLAT_TERM() returns correct error codes during negative scenarios
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 004@n
- * 
+ *
  * **Pre-Conditions:**@n
  * None.
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|---------|----------|--------------|-----|
@@ -223,7 +223,7 @@ void test_l1_plat_power_positive_PLAT_TERM (void)
  * |02|Call PLAT_INIT() - open interface | | PWRMGR_SUCCESS | Should Pass |
  * |03|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
  * |04|Call PLAT_TERM() - close interface again | | PWRMGR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note The error code PWRMGR_TERM_FAILURE is not able to be tested here.
  */
 void test_l1_plat_power_negative_PLAT_TERM (void)
@@ -248,28 +248,28 @@ void test_l1_plat_power_negative_PLAT_TERM (void)
     ret = PLAT_TERM();
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure PLAT_API_SetPowerState() returns correct error codes during positive scenarios
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 005@n
- * 
+ *
  * **Pre-Conditions:**@n
  * None.
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|---------|----------|--------------|-----|
  * |01|Call PLAT_INIT() - open interface | | PWRMGR_SUCCESS | Should Pass |
  * |02|Call PLAT_API_SetPowerState() - Iterate through various power states fetched from the profile file | newState=PWRMGR_POWERSTATE_STANDBY_DEEP_SLEEP | PWRMGR_SUCCESS | Should Pass |
  * |03|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
- * 
+ *
  */
 void test_l1_plat_power_positive_PLAT_API_SetPowerState (void)
 {
@@ -300,21 +300,21 @@ void test_l1_plat_power_positive_PLAT_API_SetPowerState (void)
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure PLAT_API_SetPowerState() returns correct error codes during negative scenarios
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 006@n
- * 
+ *
  * **Pre-Conditions:**@n
  * None.
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |01|Call PLAT_API_SetPowerState() - call without initializing the module | newState=PWRMGR_POWERSTATE_ON | PWRMGR_NOT_INITIALIZED | Should Pass |
@@ -322,7 +322,7 @@ void test_l1_plat_power_positive_PLAT_API_SetPowerState (void)
  * |03|Call PLAT_API_SetPowerState() - call with invalid value | newState=PWRMGR_POWERSTATE_MAX | PWRMGR_INVALID_ARGUMENT | Should Pass |
  * |04|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
  * |05|Call PLAT_API_SetPowerState() - call after terminating the module | newState=PWRMGR_POWERSTATE_ON | PWRMGR_NOT_INITIALIZED | Should Pass |
- *  
+ * 
  * @note The error code PWRMGR_SET_FAILURE is not able to be tested here.
  */
 void test_l1_plat_power_negative_PLAT_API_SetPowerState (void)
@@ -347,25 +347,25 @@ void test_l1_plat_power_negative_PLAT_API_SetPowerState (void)
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
-    // Step 05: Call PLAT_API_SetPowerState() - call after terminating the module   
+    // Step 05: Call PLAT_API_SetPowerState() - call after terminating the module
     ret = PLAT_API_SetPowerState(PWRMGR_POWERSTATE_ON);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure PLAT_API_GetPowerState() returns correct error codes during positive scenarios
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 007@n
- * 
+ *
  * **Pre-Conditions:**@n
  * None.
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|---------|----------|--------------|-----|
@@ -374,7 +374,7 @@ void test_l1_plat_power_negative_PLAT_API_SetPowerState (void)
  * |03|Call PLAT_API_GetPowerState() - get power state | curState* | PWRMGR_SUCCESS | Should Pass |
  * |04|Verify that PLAT_API_GetPowerState() calls returns the same value | | | Should Pass |
  * |05|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
- * 
+ *
  */
 void test_l1_plat_power_positive_PLAT_API_GetPowerState (void)
 {
@@ -401,21 +401,21 @@ void test_l1_plat_power_positive_PLAT_API_GetPowerState (void)
     // Step 05: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure PLAT_API_GetPowerState() returns correct error codes during negative scenarios
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 008@n
- * 
+ *
  * **Pre-Conditions:**@n
  * None.
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |01|Call PLAT_API_GetPowerState() - call without initializing the module | curState* | PWRMGR_NOT_INITIALIZED | Should Pass |
@@ -423,11 +423,11 @@ void test_l1_plat_power_positive_PLAT_API_GetPowerState (void)
  * |03|Call PLAT_API_GetPowerState() - call with NULL pointer | curState*=NULL | PWRMGR_INVALID_ARGUMENT | Should Pass |
  * |04|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
  * |05|Call PLAT_API_GetPowerState() - call after terminating the module | curState* | PWRMGR_NOT_INITIALIZED | Should Pass |
- *  
+ * 
  * @note The error code PWRMGR_GET_FAILURE is not able to be tested here.
  */
 void test_l1_plat_power_negative_PLAT_API_GetPowerState (void)
-{  
+{ 
     gTestID = 8;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     pmStatus_t ret;
@@ -441,7 +441,7 @@ void test_l1_plat_power_negative_PLAT_API_GetPowerState (void)
     ret = PLAT_INIT();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
-    // Step 03: Call PLAT_API_GetPowerState() - call with NULL pointer    
+    // Step 03: Call PLAT_API_GetPowerState() - call with NULL pointer
     ret = PLAT_API_GetPowerState(NULL);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_INVALID_ARGUMENT, PWRMGR_SUCCESS);
 
@@ -449,25 +449,25 @@ void test_l1_plat_power_negative_PLAT_API_GetPowerState (void)
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
-    // Step 05: Call PLAT_API_GetPowerState() - call after terminating the module    
+    // Step 05: Call PLAT_API_GetPowerState() - call after terminating the module
     ret = PLAT_API_GetPowerState(&state);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure PLAT_API_SetWakeupSrc() returns correct error codes during positive scenarios
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 009@n
- * 
+ *
  * **Pre-Conditions:**@n
  * None.
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|---------|----------|--------------|-----|
@@ -475,7 +475,7 @@ void test_l1_plat_power_negative_PLAT_API_GetPowerState (void)
  * |02|Call PLAT_API_SetWakeupSrc() - Loop through all wakeup sources and set to false| srcType=PWRMGR_WAKEUPSRC_MAX, enabled=false | PWRMGR_SUCCESS | Should Pass |
  * |03|Call PLAT_API_SetWakeupSrc() - Loop through all wakeup sources and set to true| srcType=PWRMGR_WAKEUPSRC_MAX, enabled=true | PWRMGR_SUCCESS | Should Pass |
  * |04|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
- * 
+ *
  */
 void test_l1_plat_power_positive_PLAT_API_SetWakeupSrc (void)
 {
@@ -500,13 +500,13 @@ void test_l1_plat_power_positive_PLAT_API_SetWakeupSrc (void)
         ret = PLAT_API_SetWakeupSrc(srcType, false);
         UT_LOG_DEBUG("Return status: %d", ret);
         if(ret == PWRMGR_OPERATION_NOT_SUPPORTED){
-       
+
             UT_LOG("\n Function: %s Wake up source is not supported\n", __FUNCTION__);
         }
         else{
             UT_ASSERT_EQUAL(ret, PWRMGR_SUCCESS);
         }
-    
+
     }
 
     // Step 03:Loop through all wakeup sources and set to true
@@ -516,34 +516,34 @@ void test_l1_plat_power_positive_PLAT_API_SetWakeupSrc (void)
     	ret = PLAT_API_SetWakeupSrc(srcType, true);
         UT_LOG_DEBUG("Return status: %d", ret);
         if(ret == PWRMGR_OPERATION_NOT_SUPPORTED){
-           
+
             UT_LOG("\n Function: %s Wake up source is not supported\n", __FUNCTION__);
         } 
         else{
             UT_ASSERT_EQUAL(ret, PWRMGR_SUCCESS);
         }
-    
+
     }
 
     // Step 4: Call PLAT_TERM() - close interface
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure PLAT_API_SetWakeupSrc() returns correct error codes during negative scenarios
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 010@n
- * 
+ *
  * **Pre-Conditions:**@n
  * None.
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |01|Call PLAT_API_SetWakeupSrc() - call without initializing the module | newState=PWRMGR_WAKEUPSRC_IR, enabled=false | PWRMGR_NOT_INITIALIZED | Should Pass |
@@ -551,7 +551,7 @@ void test_l1_plat_power_positive_PLAT_API_SetWakeupSrc (void)
  * |03|Call PLAT_API_SetWakeupSrc() - call with invalid value | newState=PWRMGR_WAKEUPSRC_MAX | PWRMGR_INVALID_ARGUMENT | Should Pass |
  * |04|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
  * |05|Call PLAT_API_SetWakeupSrc() - call after terminating the module | newState=PWRMGR_WAKEUPSRC_IR, enabled=false | PWRMGR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note The error code PWRMGR_SET_FAILURE is not able to be tested here.
  */
 void test_l1_plat_power_negative_PLAT_API_SetWakeupSrc (void)
@@ -580,23 +580,23 @@ void test_l1_plat_power_negative_PLAT_API_SetWakeupSrc (void)
     ret = PLAT_API_SetWakeupSrc(PWRMGR_WAKEUPSRC_IR, false);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure PLAT_API_GetWakeupSrc() returns correct error codes during positive scenarios
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 011@n
- * 
+ *
  * **Pre-Conditions:**@n
  * None.
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * todo Do the double check first
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|---------|----------|--------------|-----|
@@ -604,7 +604,7 @@ void test_l1_plat_power_negative_PLAT_API_SetWakeupSrc (void)
  * |02|Retrieve the count of supported wakeup sources from the profile file
  * |03|Call PLAT_API_GetWakeupSrc() - Retrieve and set each supported wakeup source, then get and verify its state | srcType=PWRMGR_WAKEUPSRC_MAX, *enable| PWRMGR_SUCCESS | Should Pass |
  * |04|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
- * 
+ *
  */
 void test_l1_plat_power_positive_PLAT_API_GetWakeupSrc (void)
 {
@@ -664,21 +664,21 @@ void test_l1_plat_power_positive_PLAT_API_GetWakeupSrc (void)
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure PLAT_API_GetWakeupSrc() returns correct error codes during negative scenarios
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 012@n
- * 
+ *
  * **Pre-Conditions:**@n
  * None.
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |01|Call PLAT_API_GetWakeupSrc() - call without initializing the module | srcType, *enable | PWRMGR_NOT_INITIALIZED | Should Pass |
@@ -686,7 +686,7 @@ void test_l1_plat_power_positive_PLAT_API_GetWakeupSrc (void)
  * |03|Call PLAT_API_GetWakeupSrc() - call with NULL pointer | srcType, *enable=NULL | PWRMGR_INVALID_ARGUMENT | Should Pass |
  * |04|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
  * |05|Call PLAT_API_GetWakeupSrc() - call after terminating the module | srcType, *enable | PWRMGR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note The error code PWRMGR_GET_FAILURE is not able to be tested here.
  */
 void test_l1_plat_power_negative_PLAT_API_GetWakeupSrc (void)
@@ -695,17 +695,17 @@ void test_l1_plat_power_negative_PLAT_API_GetWakeupSrc (void)
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     pmStatus_t ret;
     bool enable;
-    PWRMGR_WakeupSrcType_t srcType = PWRMGR_WAKEUPSRC_IR; 
+    PWRMGR_WakeupSrcType_t srcType = PWRMGR_WAKEUPSRC_IR;
 
     // Step 01: Call PLAT_API_GetWakeupSrc() - call without initializing the module
     ret = PLAT_API_GetWakeupSrc(srcType, &enable);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
- 
+
     // Step 02: Call PLAT_INIT() - open interface
     ret = PLAT_INIT();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
-    // Step 03: Call PLAT_API_GetWakeupSrc() - call with NULL pointer    
+    // Step 03: Call PLAT_API_GetWakeupSrc() - call with NULL pointer
     ret = PLAT_API_GetWakeupSrc(srcType, NULL);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_INVALID_ARGUMENT, PWRMGR_SUCCESS);
 
@@ -717,7 +717,7 @@ void test_l1_plat_power_negative_PLAT_API_GetWakeupSrc (void)
     ret = PLAT_API_GetWakeupSrc(srcType, &enable);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
@@ -725,21 +725,21 @@ void test_l1_plat_power_negative_PLAT_API_GetWakeupSrc (void)
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 013@n
- * 
+ *
  * **Pre-Conditions:**@n
  * None.
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|---------|----------|--------------|-----|
  * |01|Call PLAT_INIT() - open interface | | PWRMGR_SUCCESS | Should Pass |
- * |02|Retrieve the count of power states from the profile file   
+ * |02|Retrieve the count of power states from the profile file
  * |03|Call PLAT_Reset() - Loop over each power state and call PLAT_Reset() | newState=PWRMGR_POWERSTATE_STANDBY_DEEP_SLEEP | PWRMGR_SUCCESS | Should Pass |
  * |04|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
- * 
+ *
  * @note This test case is deprecated.
  */
 void test_l1_plat_power_positive_PLAT_Reset (void)
@@ -772,7 +772,7 @@ void test_l1_plat_power_positive_PLAT_Reset (void)
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
@@ -780,13 +780,13 @@ void test_l1_plat_power_positive_PLAT_Reset (void)
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 014@n
- * 
+ *
  * **Pre-Conditions:**@n
  * None.
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |01|Call PLAT_Reset() - call without initializing the module | newState=PWRMGR_POWERSTATE_ON | PWRMGR_NOT_INITIALIZED | Should Pass |
@@ -794,7 +794,7 @@ void test_l1_plat_power_positive_PLAT_Reset (void)
  * |03|Call PLAT_Reset() - call with invalid value | newState=PWRMGR_POWERSTATE_MAX | PWRMGR_INVALID_ARGUMENT | Should Pass |
  * |04|Call PLAT_TERM() - close interface | | PWRMGR_SUCCESS | Should Pass |
  * |05|Call PLAT_Reset() - call after terminating the module | newState=PWRMGR_POWERSTATE_ON | PWRMGR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note This test case is deprecated.
  * @note The error code PWRMGR_SET_FAILURE is not able to be tested here.
  */
@@ -803,7 +803,7 @@ void test_l1_plat_power_negative_PLAT_Reset (void)
     gTestID = 14;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     pmStatus_t ret;
- 
+
     // Step 01: Call PLAT_Reset() - call without initializing the module
     ret = PLAT_Reset(PWRMGR_POWERSTATE_ON);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
@@ -812,7 +812,7 @@ void test_l1_plat_power_negative_PLAT_Reset (void)
     ret = PLAT_INIT();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
-    // Step 03: Call PLAT_Reset() - call with invalid value   
+    // Step 03: Call PLAT_Reset() - call with invalid value
     ret = PLAT_Reset(PWRMGR_POWERSTATE_MAX);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_INVALID_ARGUMENT, PWRMGR_SUCCESS);
 
@@ -820,11 +820,11 @@ void test_l1_plat_power_negative_PLAT_Reset (void)
     ret = PLAT_TERM();
     UT_ASSERT_EQUAL_FATAL(ret, PWRMGR_SUCCESS);
 
-    // Step 05: Call PLAT_Reset() - call after terminating the module    
+    // Step 05: Call PLAT_Reset() - call after terminating the module
     ret = PLAT_Reset(PWRMGR_POWERSTATE_ON);
     CHECK_FOR_EXTENDED_ERROR_CODE( ret, PWRMGR_NOT_INITIALIZED, PWRMGR_SUCCESS);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 static UT_test_suite_t * pSuite = NULL;
@@ -840,8 +840,8 @@ int test_l1_plat_power_register ( void )
     pSuite = UT_add_suite( "[L1 plat_power]", NULL, NULL );
     if ( NULL == pSuite )
     {
-        return -1;
-    }	
+       return -1;
+    }
 
     UT_add_test( pSuite, "PLAT_INIT_L1_positive" ,test_l1_plat_power_positive_PLAT_INIT );
     UT_add_test( pSuite, "PLAT_INIT_L1_negative" ,test_l1_plat_power_negative_PLAT_INIT );
@@ -857,10 +857,10 @@ int test_l1_plat_power_register ( void )
     UT_add_test( pSuite, "PLAT_API_GetWakeupSrc_L1_negative" ,test_l1_plat_power_negative_PLAT_API_GetWakeupSrc );
     UT_add_test( pSuite, "PLAT_Reset_L1_positive" ,test_l1_plat_power_positive_PLAT_Reset );
     UT_add_test( pSuite, "PLAT_Reset_L1_negative" ,test_l1_plat_power_negative_PLAT_Reset );
-    extendedEnumsSupported = ut_kvp_getBoolField( ut_kvp_profile_getInstance(), "powermanager/features/extendedEnumsSupported" );	
+    extendedEnumsSupported = ut_kvp_getBoolField( ut_kvp_profile_getInstance(), "powermanager/features/extendedEnumsSupported" );
 
     return 0;
-} 
+}
 /** @} */ // End of PLAT_POWER_HALTEST_L1
 /** @} */ // End of POWER_MANAGER_HALTEST
 /** @} */ // End of POWER_MANAGER

--- a/src/test_l1_plat_power.c
+++ b/src/test_l1_plat_power.c
@@ -635,7 +635,7 @@ void test_l1_plat_power_positive_PLAT_API_GetWakeupSrc (void)
         UT_ASSERT_EQUAL(ret, PWRMGR_SUCCESS);
         if (ret != PWRMGR_SUCCESS) {
             UT_LOG_ERROR("Failed to set Wakeup Src");
-            continue;
+
         }
 
        UT_LOG_DEBUG("Invoking PLAT_API_GetWakeupSrc with srcType: %d", srcType);
@@ -650,7 +650,7 @@ void test_l1_plat_power_positive_PLAT_API_GetWakeupSrc (void)
        UT_ASSERT_EQUAL(ret, PWRMGR_SUCCESS);
        if (ret != PWRMGR_SUCCESS) {
             UT_LOG_ERROR("Failed to set Wakeup Src");
-            continue;
+
        }
 
        UT_LOG_DEBUG("Invoking PLAT_API_GetWakeupSrc with srcType: %d", srcType);


### PR DESCRIPTION
 1. Clean up unnecessary code in L1:
   Removed the unused variables, and macros and compiled with zero warnings.
   FATAL used in all tests is removed except for init and term APIs.  
   Reviewed the usage of casting.
   
 2. Re-checked if any new API interface has been added recently and requires an L1 test case, no new API interface was found.

