### PR TITLE
gh #49 binary copied to wrong directory

### DIFF
--- a/host/tests/L1_L2_TestCases/powermanager_L1_L2_tests.py
+++ b/host/tests/L1_L2_TestCases/powermanager_L1_L2_tests.py
@@ -80,10 +80,10 @@ class powermanager_L1_L2_tests(utHelperClass):
         # Copy bin files to the target
         for artifact in self.testConfig.test.artifacts:
             filesPath = os.path.join(dir_path, artifact)
-            self.baseUtils.rsync(self.hal_session, filesPath, targetWorkspace)
+            self.baseUtils.rsync(self.hal_session, filesPath, self.targetWorkspace)
 
         # Copy the profile file to the target
-        self.baseUtils.scpCopy(self.hal_session, self.moduleConfigProfileFile, targetWorkspace)
+        self.baseUtils.scpCopy(self.hal_session, self.moduleConfigProfileFile, self.targetWorkspace)
 
     def runTest(self, testsuite_name:str, test_case:str=None):
         """


### PR DESCRIPTION
In the place of rsync and scp the variable name of targetWorkspace is wrong.. Need to give as self. targetWorkspace instead of targetWorkspace